### PR TITLE
Avoid warning on quoted coveralls reference in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule EctoAutoslugField.Mixfile do
      # Test coverage:
      test_coverage: [tool: ExCoveralls],
      preferred_cli_env: [
-       "coveralls": :test,
+       coveralls: :test,
        "coveralls.detail": :test,
        "coveralls.post": :test,
        "coveralls.html": :test,


### PR DESCRIPTION
I made this PR because I was just seeing this warning everytime I was launching my project, and life is better without warnings 😊:

```
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in them
  ./deps/ecto_autoslug_field/mix.exs:26
```

Thanks.
