### PR TITLE
Fix Ecto 3.2 warnings

### DIFF
--- a/lib/ecto_autoslug_field/slug.ex
+++ b/lib/ecto_autoslug_field/slug.ex
@@ -157,7 +157,7 @@ defmodule EctoAutoslugField.Slug do
 
         It basically just calls the methods of the basic `Type` module.
         """
-        @behaviour Ecto.Type
+        use Ecto.Type
 
         alias EctoAutoslugField.Type
 

--- a/lib/ecto_autoslug_field/type.ex
+++ b/lib/ecto_autoslug_field/type.ex
@@ -3,7 +3,7 @@ defmodule EctoAutoslugField.Type do
   This module represents a simple wrapper around ':string' Ecto type.
   """
 
-  @behaviour Ecto.Type
+  use Ecto.Type
 
   def type, do: :string
 


### PR DESCRIPTION
Ecto 3.2 adds some new required callbacks to Ecto.Type.

Changing from `@behaviour Ecto.Type` to `use Ecto.Type` fixes the warnings.